### PR TITLE
Add empty constructor

### DIFF
--- a/include/kernelDB.h
+++ b/include/kernelDB.h
@@ -142,6 +142,7 @@ private:
 class __attribute__((visibility("default"))) kernelDB {
 public:
     kernelDB(hsa_agent_t agent, const std::string& fileName);
+    kernelDB(hsa_agent_t agent);
     ~kernelDB();
     bool getBasicBlocks(const std::string& name, std::vector<basicBlock>&);
     const CDNAKernel& getKernel(const std::string& name);

--- a/src/kernelDB.cc
+++ b/src/kernelDB.cc
@@ -194,6 +194,8 @@ kernelDB::kernelDB(hsa_agent_t agent, const std::string& fileName)
     }
 }
 
+kernelDB::kernelDB(hsa_agent_t agent) : agent_{agent} {}
+
 kernelDB::~kernelDB()
 {
    std::cout << "Ending kernelDB\n";


### PR DESCRIPTION
This PR adds an empty constructor so that KernelDB users can do:

```c++
kdb_ = std::make_unique<kernelDB::kernelDB>(gpu_agent.agent);
kdb_->addFile(filename, agent, "");
```