### PR TITLE
Add pybind11-global package as a build dep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # Copyright (c) 2024 Advanced Micro Devices, Inc. All rights reserved.
 
 [build-system]
-requires = ["setuptools>=61", "wheel", "cmake>=3.18", "setuptools-scm>=8", "pybind11>=2.6"]
+requires = ["setuptools>=61", "wheel", "cmake>=3.18", "setuptools-scm>=8", "pybind11>=2.6", "pybind11-global>=3.0.0"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
Fixes a circular import error that occurs during wheel install. After spending some time debugging the Python vir env, we found the problem was a missing `pybind11-global` package. After adding this, the issue goes away.

Added `pybind11-global` to the **pyproject.toml** file as a build dep to ensure that this is automatically installed for users. Tested this out in a clean env and I can confirm this solves the issue.

Closes #14 