### PR TITLE
Add license-files entry to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ description = "C++ library for querying data within CDNA kernel implementations,
 authors = [
     { name = "Keith Lowery", email = "Keith.Lowery@amd.com" },
 ]
-license = {text = "MIT"}
+license-files = ["LICENSE"]
 readme = "README.md"
 requires-python = ">=3.8"
 dependencies = []


### PR DESCRIPTION
Licensing description is changing and `uv` reports a warning:

```
      /home/ypapadop/.cache/uv/builds-v0/.tmpHcCZjO/lib/python3.12/site-packages/setuptools/config/_apply_pyprojecttoml.py:82: SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated
      !!

              ********************************************************************************
              Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).

              By 2026-Feb-18, you need to update your project and remove deprecated calls
              or your builds will no longer be supported.

              See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
              ********************************************************************************

      !!
```

This fixes that warning.