### PR TITLE
Fix get_file_name segfault: use 1-based index

### DIFF
--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -144,4 +144,4 @@ def test_basic_blocks_and_kernel_wrapper():
     filtered = kernel.get_instructions_for_line(first_line, ".*load.*")
     assert len(filtered) <= len(insts)
 
-    assert isinstance(kdb.get_file_name(name, 0), str)
+    assert isinstance(kdb.get_file_name(name, 1), str)


### PR DESCRIPTION
## Summary
- `get_file_name(name, 0)` causes a segfault because the C++ implementation uses 1-based indexing: `file_names_[index-1]`
- With `index=0`, `index-1` underflows to `SIZE_MAX` on unsigned `size_t`, causing an out-of-bounds access
- The assert in the C++ code (`assert(index <= file_names_.size())`) incorrectly allows `index=0` and is stripped in release builds anyway
- This was the flaky CI failure on main — it segfaults depending on memory layout

## Fix
Changed `get_file_name(name, 0)` to `get_file_name(name, 1)` in the test.

The C++ side should also be hardened (bounds check instead of assert, or switch to 0-based indexing), but that's a separate change.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>