### PR TITLE
Remove unused zstd and zlib link dependencies

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -62,8 +62,6 @@ target_link_libraries(
     stdc++
     stdc++fs
     amd_comgr
-    z
-    zstd
     dwarf
     elf
 )


### PR DESCRIPTION
## Summary

- Remove `zstd` and `z` (zlib) from `target_link_libraries` in `src/CMakeLists.txt`
- Neither library is included or called anywhere in the source code
- CCOB decompression is delegated to `clang-offload-bundler`, not handled natively

This eliminates the `libzstd-dev` and `zlib1g-dev` build requirements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)